### PR TITLE
autoupdate/Bump pr_emitter to 2023.3.132

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@luislongo/pr_emitter": {
-      "version": "2023.3.98",
-      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.98/516139ca3e7db8a5dd51ca09aacec0f7a3d70473",
-      "integrity": "sha512-BvNjR88wh0rk3ESKXcrhTJ5hm4Z9LTw8qqWu4Nr6ZWS01E1j5swH+4lQSZwFge1GcjL54KygSgQmOBpP5J2+7A==",
+      "version": "2023.3.132",
+      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.132/0e2629c75bb7dad7623d5445f910e8cff419614f",
+      "integrity": "sha512-diEQVICMbFOqzBijXXkA3PEtCr8vYaSytxQUcAcHcfYZa720GsMGhP+eWcEWoRgGzPeZmX2aa/9XCCVZXsjptA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@luislongo/pr_emitter": "^2023.3.98",
+    "@luislongo/pr_emitter": "^2023.3.132",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",


### PR DESCRIPTION
This PR updates pr_emitter version to 2023.3.132 based on the dispatched event.