### PR TITLE
autoupdate/Bump @luislongo/pr_emitter to 2023.3.162

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@luislongo/pr_emitter": {
-      "version": "2023.3.161",
-      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.161/df27af15a25c619bc5a7818677b990e2b3db410d",
-      "integrity": "sha512-S/Uvnvk2IiA4va/TXprbbDw12fGJVyqUyhaS4bghIg+hPuIdN5fEX1xBHQ2nHKzLN0mrfSFpPWiGeuT56PU+Qg==",
+      "version": "2023.3.162",
+      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.162/e570a58f33626dba23d0297ef70ddce04228eb18",
+      "integrity": "sha512-/5hOcrBJ9tszMN9bC7q/a/OIHviYApGBsnGlmyy5eRbhV3kXyJxMqUKaesdEITVwIqKHYx5bmouTnEH8UiuHSw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@luislongo/pr_emitter": "^2023.3.161",
+    "@luislongo/pr_emitter": "^2023.3.162",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",


### PR DESCRIPTION
This PR updates @luislongo/pr_emitter version to 2023.3.162 based on the dispatched event.