### PR TITLE
autoupdate/Bump @luislongo/pr_emitter to 2023.3.194

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@luislongo/pr_emitter": {
-      "version": "2023.3.192",
-      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.192/5312b1a0e7acd73159a9525ce155fa6872292196",
-      "integrity": "sha512-LYWaonu3MqEzOmpjEgT1pg0ajCLmXIWVYGp44/PDHnurd5rMIscRKZWGZXTwx220D9otE2PtBA91/IY3fzEigw==",
+      "version": "2023.3.194",
+      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.194/ee7e9f3286914cdb8d2c1909a34cfe15175f8452",
+      "integrity": "sha512-0NoAOxVfUyPnt/IiTASdABiUqPPEWsiAdXSGbQypGg7dNsdIbuQtNOb7i8H8tZxnr0hXi7stF6V6C7cB7ZccEw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@luislongo/pr_emitter": "2023.3.192",
+    "@luislongo/pr_emitter": "2023.3.194",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",


### PR DESCRIPTION
This PR updates @luislongo/pr_emitter version to 2023.3.194 based on the dispatched event.