### PR TITLE
autoupdate/Bump @luislongo/pr_emitter to 2023.3.196

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@luislongo/pr_emitter": {
-      "version": "2023.3.195",
-      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.195/dc1de7c02a950700482befb97595c6d18d7b852e",
-      "integrity": "sha512-6tOB8C50J3gQ8ipv7jBzUub4jx9hhKItrTXwkMakrh9aLDA/Hkmz4dCABtzyu/1QJ6e/uI+1q5ZLyR5xZbaLvg==",
+      "version": "2023.3.196",
+      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.196/e293b069d39b26cee2774775a3e8854824ff1004",
+      "integrity": "sha512-pcVJK5+TURmmjb5qkn+pHqTVAvuIaBYu7b9Czs3V5bDZgVEAsT7IgNU5FA/CNt8YSHKWKdfD+vyjBdNGpLxuCw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@luislongo/pr_emitter": "2023.3.195",
+    "@luislongo/pr_emitter": "2023.3.196",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",


### PR DESCRIPTION
This PR updates @luislongo/pr_emitter version to 2023.3.196 based on the dispatched event.