### PR TITLE
autoupdate/Bump @luislongo/pr_emitter to 2023.3.197

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@luislongo/pr_emitter": {
-      "version": "2023.3.196",
-      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.196/e293b069d39b26cee2774775a3e8854824ff1004",
-      "integrity": "sha512-pcVJK5+TURmmjb5qkn+pHqTVAvuIaBYu7b9Czs3V5bDZgVEAsT7IgNU5FA/CNt8YSHKWKdfD+vyjBdNGpLxuCw==",
+      "version": "2023.3.197",
+      "resolved": "https://npm.pkg.github.com/download/@luislongo/pr_emitter/2023.3.197/d48e3d99a290b13a07fe0b2ed5123259d941e1c9",
+      "integrity": "sha512-dsER+zvdTL7Bf9sq3Hnx+DECAItbeOkgbMnUukZhHh3iLMX2kmQneQVOPcV36FoQ+rzHDsEJMyL3Y2LG8x4xWQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@luislongo/pr_emitter": "2023.3.196",
+    "@luislongo/pr_emitter": "2023.3.197",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",


### PR DESCRIPTION
This PR updates @luislongo/pr_emitter version to 2023.3.197 based on the dispatched event.